### PR TITLE
Move background-image to body instead of *

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,10 +1,10 @@
 * {
-    background-image: url("background.png");
     color: lime;
     font-family: "Lucida Console", Monaco, monospace;
 }
 body {
-    text-align: center
+    text-align: center;
+    background-image: url("background.png");
 }
 h1 {
     font-size: 42pt;


### PR DESCRIPTION
Background-image on * means that every element has a separate version of the background-image behind it, which creates strange jitter effects that are particularly noticeable when generating the next attribution.